### PR TITLE
don't use text for urls

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -479,7 +479,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *event)
     qDebug() << event->mimeData()->urls();
 #endif
     if (event->mimeData()->hasFormat("text/uri-list"))
-        if ((event->mimeData()->text().endsWith("iso")) || (event->mimeData()->text().endsWith("raw")))
+        if ((event->mimeData()->urls()[0].toString().endsWith("iso")) || (event->mimeData()->urls()[0].toString().endsWith("raw")))
             event->acceptProposedAction();
 }
 


### PR DESCRIPTION
text may contain \r\n at the end so use Qt's urls() method to check if a
file is valid.

https://bugzilla.suse.com/show_bug.cgi?id=915314#c3