### PR TITLE
Port to QT5

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -28,6 +28,12 @@
 #include <QtDBus>
 #include <QFile>
 #include <QDebug>
+#include <QVBoxLayout>
+#include <QStackedLayout>
+#include <QPushButton>
+#include <QDesktopWidget>
+#include <QMessageBox>
+#include <QApplication>
 
 #include <unistd.h>
 #include <sys/types.h>

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -27,6 +27,8 @@
 #include <QtGui>
 #include <QWidget>
 #include <QDBusMessage>
+#include <QLabel>
+#include <QComboBox>
 
 #include "MetaTypes.h"
 #include "Platform.h"

--- a/Platform.cpp
+++ b/Platform.cpp
@@ -11,7 +11,6 @@
 #include <errno.h>
 
 #define BLOCKSIZE 1048576
-#define _GNU_SOURCE
 
 Platform::Platform(bool kioskMode, bool unsafe)
 {

--- a/PlatformUdisks.cpp
+++ b/PlatformUdisks.cpp
@@ -32,6 +32,7 @@
 #include <QRegExp>
 #include <QDir>
 #include <QProgressDialog>
+#include <QMessageBox>
 
 #include "DeviceItem.h"
 #include "PlatformUdisks.h"

--- a/PlatformUdisks2.cpp
+++ b/PlatformUdisks2.cpp
@@ -10,6 +10,7 @@
 #include <QRegExp>
 #include <QDir>
 #include <QProgressDialog>
+#include <QMessageBox>
 
 #include <QtDBus/QDBusConnection>
 #include <QtDBus/QDBusPendingReply>

--- a/imagewriter.pro
+++ b/imagewriter.pro
@@ -9,6 +9,8 @@ INCLUDEPATH += .
 DESTDIR += .
 VERSION=1.10
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"
+QMAKE_CXXFLAGS_RELEASE += "-fvisibility=hidden -fvisibility-inlines-hidden"
+QT  += dbus gui widgets
 
 # Input
 HEADERS += DeviceItem.h \
@@ -29,8 +31,8 @@ SOURCES += main.cpp \
     udisks2_interface.cpp \
     udisks2_mountpoints_interface.cpp
 
-CONFIG += link_pkgconfig \
-    qdbus
+CONFIG += c++11 link_pkgconfig
+
 
 exists("/usr/include/hal/libhal.h") { 
     PKGCONFIG += hal \

--- a/main.cpp
+++ b/main.cpp
@@ -113,7 +113,7 @@ main (int argc, char *argv[])
         for (i = list.begin(); i != list.end(); ++i)
         {
             if (!(*i)->getPath().isEmpty())
-                fprintf(stdout, "%s\n", (*i)->getPath().toAscii().data());
+                fprintf(stdout, "%s\n", (*i)->getPath().toLatin1().data());
         }
         exit(0);
     }


### PR DESCRIPTION
By the end of 2015, QT 4.x upstream support will end, therefore
it is needed to move to QT5

Tested with QT 5.4.1 in openSUSE Tumbleweed.