### PR TITLE
Load image file when opening from file manager

### DIFF
--- a/imagewriter.desktop
+++ b/imagewriter.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=System;Utility;Archiving;
-Exec=imagewriter %f
+Exec=imagewriter -f %f
 Icon=imagewriter
 Name=SUSE Studio Imagewriter
 GenericName=USB key writer


### PR DESCRIPTION
When opening an image file from a filemanager the file is not loaded. Now the opened file is actually selected in imagewriter