### PR TITLE
Adjust partition numbering.

### DIFF
--- a/PlatformUdisks2.cpp
+++ b/PlatformUdisks2.cpp
@@ -51,7 +51,7 @@ PlatformUdisks2::udisk2Enabled()
 void
 PlatformUdisks2::findDevices()
 {
-    QRegExp reg("[0-9]+$");
+    QRegExp reg("[1-9]+$");
 
     if (!udisk2Enabled())
     {


### PR DESCRIPTION
This change allows using SD cards that are visible by the system as /org/freedesktop/UDisks2/block_devices/mmcblk0
All standard devices (sdX, nvme) count partitions starting from 1.