### PR TITLE
Adjust partition numbering.

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -338,7 +338,7 @@ void MainWindow::deviceInserted(const QDBusObjectPath &object_path,
 {
     Q_UNUSED(interfaces_and_properties);
 
-    QRegExp reg("[0-9]+$");
+    QRegExp reg("[1-9]+$");
     QString path = object_path.path();
 
     if (!path.startsWith("/org/freedesktop/UDisks2/block_devices"))
@@ -360,7 +360,7 @@ void MainWindow::deviceRemoved(const QDBusObjectPath &object_path,
 {
     Q_UNUSED(interfaces);
 
-    QRegExp reg("[0-9]+$");
+    QRegExp reg("[1-9]+$");
     QString path = object_path.path();
 
     if (!path.startsWith("/org/freedesktop/UDisks2/block_devices"))

--- a/PlatformUdisks2.cpp
+++ b/PlatformUdisks2.cpp
@@ -51,7 +51,7 @@ PlatformUdisks2::udisk2Enabled()
 void
 PlatformUdisks2::findDevices()
 {
-    QRegExp reg("[0-9]+$");
+    QRegExp reg("[1-9]+$");
 
     if (!udisk2Enabled())
     {


### PR DESCRIPTION
This change allows using SD cards that are visible by the system as /org/freedesktop/UDisks2/block_devices/mmcblk0
All standard devices (sdX, nvme) count partitions starting from 1.