### PR TITLE
refactor: add support for Qt6

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -31,13 +31,12 @@
 #include <QVBoxLayout>
 #include <QStackedLayout>
 #include <QPushButton>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QMessageBox>
 #include <QApplication>
 
 #include <unistd.h>
 #include <sys/types.h>
-#include <sys/sysctl.h>
 
 #ifdef USEUDISKS2
 #include "udisks2_interface.h"
@@ -128,8 +127,8 @@ void
 MainWindow::reloadDeviceList(const char *cmddevice)
 {
     int dev = -1;
-    QLinkedList<DeviceItem *> list = pPlatform->getDeviceList();
-    QLinkedList<DeviceItem *>::iterator i;
+    QList<DeviceItem *> list = pPlatform->getDeviceList();
+    QList<DeviceItem *>::iterator i;
     for (i = list.begin(); i != list.end(); ++i)
     {
         if (!(*i)->getPath().isEmpty())
@@ -138,7 +137,7 @@ MainWindow::reloadDeviceList(const char *cmddevice)
 
         if (cmddevice != NULL)
             if ((*i)->getPath().compare(cmddevice) == 0)
-                dev = deviceComboBox->findText((*i)->getDisplayString(), 0);
+                dev = deviceComboBox->findText((*i)->getDisplayString(), Qt::MatchExactly);
     }
 
     if (dev != -1)
@@ -265,16 +264,15 @@ MainWindow::useOldUI()
 void
 MainWindow::centerWindow()
 {
-    QDesktopWidget *desktop = QApplication::desktop();
+    QScreen *screen = QApplication::primaryScreen();
 
     int screenWidth, width;
     int screenHeight, height;
     int x, y;
-    int screen = desktop->screenNumber(this);
     QSize windowSize;
 
-    screenWidth = desktop->screenGeometry(screen).width();
-    screenHeight = desktop->screenGeometry(screen).height();
+    screenWidth = screen->geometry().width();
+    screenHeight = screen->geometry().height();
 
     windowSize = size();
     width = windowSize.width();
@@ -338,7 +336,7 @@ void MainWindow::deviceInserted(const QDBusObjectPath &object_path,
 {
     Q_UNUSED(interfaces_and_properties);
 
-    QRegExp reg("[0-9]+$");
+    QRegularExpression reg("[0-9]+$");
     QString path = object_path.path();
 
     if (!path.startsWith("/org/freedesktop/UDisks2/block_devices"))
@@ -360,7 +358,7 @@ void MainWindow::deviceRemoved(const QDBusObjectPath &object_path,
 {
     Q_UNUSED(interfaces);
 
-    QRegExp reg("[0-9]+$");
+    QRegularExpression reg("[0-9]+$");
     QString path = object_path.path();
 
     if (!path.startsWith("/org/freedesktop/UDisks2/block_devices"))
@@ -370,8 +368,8 @@ void MainWindow::deviceRemoved(const QDBusObjectPath &object_path,
         return;
 
     QString udi = path.mid(path.lastIndexOf("/") + 1);
-    QLinkedList<DeviceItem *> list = pPlatform->getDeviceList();
-    QLinkedList<DeviceItem *>::iterator i;
+    QList<DeviceItem *> list = pPlatform->getDeviceList();
+    QList<DeviceItem *>::iterator i;
     for (i = list.begin(); i != list.end(); ++i)
     {
         if ((*i)->getUDI() == udi)
@@ -421,8 +419,8 @@ MainWindow::deviceRemoved(QDBusMessage message)
     if (devicePath.startsWith("/org/freedesktop/UDisks/devices/"))
 #endif
     {
-        QLinkedList<DeviceItem *> list = pPlatform->getDeviceList();
-        QLinkedList<DeviceItem *>::iterator i;
+        QList<DeviceItem *> list = pPlatform->getDeviceList();
+        QList<DeviceItem *>::iterator i;
         for (i = list.begin(); i != list.end(); ++i)
         {
             if ((*i)->getUDI() == devicePath)

--- a/Platform.cpp
+++ b/Platform.cpp
@@ -22,13 +22,14 @@ bool
 Platform::removeDeviceFromList(const QString &displayName)
 {
     DeviceItem *item = NULL;
-    QLinkedList<DeviceItem *>::iterator i;
+    QList<DeviceItem *>::iterator i;
     for (i = itemList.begin(); i != itemList.end(); ++i)
     {
         if ((*i)->getDisplayString() == displayName)
         {
             item = (*i);
             itemList.erase(i);
+            break;
         }
     }
 
@@ -43,7 +44,7 @@ DeviceItem *
 Platform::findDeviceInList(const QString &displayName)
 {
     DeviceItem *retItem = NULL;
-    QLinkedList<DeviceItem *>::iterator i;
+    QList<DeviceItem *>::iterator i;
     for (i = itemList.begin(); i != itemList.end(); ++i)
     {
         if ((*i)->getDisplayString() == displayName)

--- a/Platform.h
+++ b/Platform.h
@@ -37,7 +37,7 @@ public:
     bool removeDeviceFromList(const QString &displayName);
     DeviceItem *findDeviceInList(const QString &displayName);
     void writeData(DeviceItem* item, QString fileName);
-    QLinkedList<DeviceItem *> getDeviceList() { return itemList; }
+    QList<DeviceItem *> getDeviceList() { return itemList; }
 
     virtual int open(DeviceItem* item);
     virtual void findDevices() {}
@@ -49,7 +49,7 @@ protected:
     bool mUnsafe;
     bool mKioskMode;
     DeviceItem *pDevice;
-    QLinkedList<DeviceItem *> itemList;
+    QList<DeviceItem *> itemList;
 };
 
 #endif

--- a/PlatformUdisks.cpp
+++ b/PlatformUdisks.cpp
@@ -29,7 +29,7 @@
 
 #include <QtCore>
 #include <QtGui>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QDir>
 #include <QProgressDialog>
 #include <QMessageBox>
@@ -91,7 +91,7 @@ PlatformUdisks::findDevices()
 
     QList<QDBusObjectPath> list = reply.value();
     QStringList devList;
-    QRegExp reg("[0-9]+$");
+    QRegularExpression reg("[0-9]+$");
 
     // Ignore partition slices
     for (i = 0; i < list.size(); ++i)
@@ -385,7 +385,8 @@ PlatformUdisks::getPartitionList(const QString &devicePath)
     }
 
     QList<QDBusObjectPath> list = reply.value();
-    QRegExp reg(QString("%1[0-9]+$").arg(devicePath));
+    QRegularExpression reg(QString("%1[0-9]+$").arg(devicePath));
+
     for (int i = 0; i < list.size(); ++i)
         if (list.at(i).path().contains(reg))
             devList << list.at(i).path();

--- a/PlatformUdisks2.cpp
+++ b/PlatformUdisks2.cpp
@@ -7,7 +7,7 @@
 
 #include <QtCore>
 #include <QtGui>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QDir>
 #include <QProgressDialog>
 #include <QMessageBox>
@@ -51,7 +51,7 @@ PlatformUdisks2::udisk2Enabled()
 void
 PlatformUdisks2::findDevices()
 {
-    QRegExp reg("[0-9]+$");
+    QRegularExpression reg("[0-9]+$");
 
     if (!udisk2Enabled())
     {
@@ -250,7 +250,7 @@ PlatformUdisks2::getPartitionList(const QString &devicePath)
         exit(0);
     }
 
-    QRegExp reg(QString("%1[0-9]+$").arg(devicePath));
+    QRegularExpression reg(QString("%1[0-9]+$").arg(devicePath));
 
     Q_FOREACH(const QDBusObjectPath &path, reply.value().keys()) {
         const QString udi = path.path();

--- a/main.cpp
+++ b/main.cpp
@@ -108,8 +108,8 @@ main (int argc, char *argv[])
 
     if (listMode)
     {
-        QLinkedList<DeviceItem *> list = platform->getDeviceList();
-        QLinkedList<DeviceItem *>::iterator i;
+        QList<DeviceItem *> list = platform->getDeviceList();
+        QList<DeviceItem *>::iterator i;
         for (i = list.begin(); i != list.end(); ++i)
         {
             if (!(*i)->getPath().isEmpty())


### PR DESCRIPTION
This PR enables compilation of Imagewriter with Qt6. 

- use `QList` instead of `QLinkedList`
- use `QRegularExpression` instead of `QRegExp`
- use `QScreen` instead of `QDesktopWidget`

Others:
- remove `#include <sys/sysctl.h>` (see also PR #28)
- fix: leave loop in `Platform::removeDeviceFromList` when item found as `erase` invalidates iterator

Note: these changes break compatibility with Qt4

Note: in [End of Qt 5 support](https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/UW6BKTYQ6OX3TCFIDXAVAXVL33V65NRD/) the Imagewriter is listed as "unmaintained". I hope this PR will allow us to continue including Imagewriter in TW and Leap 16.