### PR TITLE
fix: dark mode support

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -156,11 +156,6 @@ MainWindow::useNewUI()
     QHBoxLayout *pathSizeLayout;
     QPushButton *writeButton;
 
-    // Set the background colour
-    QPalette pal = palette();
-    pal.setColor(QPalette::Window, Qt::white);
-    setPalette(pal);
-
     imageLabel = new CustomLabel(this);
     imageLabel->setBackgroundRole(QPalette::Base);
     imageLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);


### PR DESCRIPTION
This very simple PR addresses issue #26 by just removing one line of the code.

Currently the background color is defined to be white irrespective of the color mode of the desktop environment:

```c++
    pal.setColor(QPalette::Window, Qt::white);
```

I propose to use the default background color for the main window by just removing this code. This makes the main window appear light gray in light mode and dark gray in dark mode, depending on the color definitions of the desktop environment.

An alternative implementation, which keeps the look of the current light mode, would be to replace the line by

```c++
    pal.setColor(QPalette::Window, pal.color(QPalette::Base));
```

This would assign the base color to the background of the main window. The base color is typically used as background in active text entry fields. This would make the background brighter in light mode and darker in dark mode.

My preference is however to stick to the colors of the theme.

Fixes #26