### PR TITLE
fix: QString from QByteArray changes with Qt6

### DIFF
--- a/PlatformUdisks2.cpp
+++ b/PlatformUdisks2.cpp
@@ -113,7 +113,9 @@ PlatformUdisks2::getBlockDeviceProperties(const QString &blockDevice)
     QDBusObjectPath objectPath = qvariant_cast<QDBusObjectPath>(remoteApp.property("Drive"));
     QString path = objectPath.path();
     properties.insert("drivePath", path);
-    properties.insert("path", QString(remoteApp.property("Device").toByteArray()));
+    QString device = remoteApp.property("Device").toByteArray();
+    device.remove('\0');
+    properties.insert("path", device);
     properties.insert("size", remoteApp.property("Size"));
     return properties;
 }


### PR DESCRIPTION
This bug was detected by Edgar Aichinger while building the package on OBS for TW.

- in Qt6, the behavior of the QString(QByteArray) constructor was changed, see https://doc.qt.io/qt-6/qstring.html#QString-4
- this causes a NULL byte at the end of a QByteArray to be included in the resulting QString
- this again causes problems when the result is used to construct further DBus calls
- remove NULL bytes from QByteArray to fix this